### PR TITLE
Revert "Skip test when the GLIBC race conditions are met, instead of failing"

### DIFF
--- a/.pylint-spelling-words
+++ b/.pylint-spelling-words
@@ -28,7 +28,6 @@ favicons
 fds
 freebsd
 getsockname
-glibc
 https
 ico
 illumos

--- a/changelog/16.improvement.rst
+++ b/changelog/16.improvement.rst
@@ -1,0 +1,3 @@
+Revert `"Skip test when the GLIBC race conditions are met, instead of failing." <https://github.com/saltstack/pytest-shell-utilities/commit/f79aba3c5c0c7e4bdd895ae422d2f35ed22ea2e6>`_
+
+It wasn't the right fix/workaround. The right fix can be seen in `the Salt repo <https://github.com/saltstack/salt/pull/62078>`_

--- a/src/pytestshellutils/downgraded/shell.py
+++ b/src/pytestshellutils/downgraded/shell.py
@@ -14,7 +14,6 @@ import pathlib
 import shutil
 import subprocess
 import sys
-from functools import lru_cache
 from tempfile import SpooledTemporaryFile
 from typing import Any
 from typing import Callable
@@ -26,10 +25,8 @@ from typing import Optional
 from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
-import _pytest._version
 import attr
 import psutil
-import pytest
 from pytestskipmarkers.utils import platform
 from pytestshellutils.customtypes import Callback
 from pytestshellutils.customtypes import EnvironDict
@@ -49,33 +46,7 @@ from pytestshellutils.utils.processes import terminate_process_list
 if TYPE_CHECKING:
     from typing import Type
     from pytestsysstats.plugin import StatsProcesses
-PYTEST_GE_7 = getattr(_pytest._version, 'version_tuple', (-1, -1)) >= (7, 0)
 log = logging.getLogger(__name__)
-
-
-@lru_cache(maxsize=1, typed=False)
-def glibc_prone_to_race_condition() -> bool:
-    """
-    Check if the GLIBC version is prone to race conditions.
-
-    This should be fixed after version 2.34 of GLIBC
-
-    See:
-        https://sourceware.org/bugzilla/show_bug.cgi?id=19329
-    """
-    ret = subprocess.run(
-        ['ldd', '--version'],
-        universal_newlines=True,
-        check=True,
-        shell=False,
-        stdout=subprocess.PIPE,
-    )
-    glibc_version = tuple(
-        int(x) for x in ret.stdout.splitlines()[0].split()[-1].split('.') if x.isdigit()
-    )
-    if glibc_version >= (2, 34):
-        return False
-    return True
 
 
 @attr.s(slots=True, kw_only=True)
@@ -87,13 +58,10 @@ class BaseFactory:
         The path to the desired working directory
     :keyword dict environ:
         A dictionary of ``key``, ``value`` pairs to add to the environment.
-    :keyword bool skip_on_glibc_race_condition_hit:
-        Whether to skip test or not when the glibc race conditions are seen.
     """
 
     cwd = attr.ib(converter=resolved_pathlib_path)
     environ = attr.ib(repr=False)
-    skip_on_glibc_race_condition_hit = attr.ib(default=True)
 
     @cwd.default
     def _default_cwd(self) -> pathlib.Path:
@@ -281,22 +249,6 @@ class SubprocessImpl:
                 cmdline=cast(List[str], self._terminal.args),
             )
             log.info('%s %s', self.factory.__class__.__name__, self._terminal_result)
-            if (
-                self._terminal_result.returncode == 127
-                and glibc_prone_to_race_condition()
-            ):
-                if (
-                    stderr
-                    and 'Inconsistency detected by ld.so' in stderr
-                    and '_dl_allocate_tls_init' in stderr
-                ) and self.factory.skip_on_glibc_race_condition_hit:
-                    exc_kwargs = {}
-                    if PYTEST_GE_7:
-                        exc_kwargs['_use_item_location'] = True
-                    raise pytest.skip.Exception(
-                        'GLIBC race condition bug hit. See https://sourceware.org/bugzilla/show_bug.cgi?id=19329',
-                        **exc_kwargs,
-                    )
             return self._terminal_result
         finally:
             self._terminal = None


### PR DESCRIPTION
This reverts commit f79aba3c5c0c7e4bdd895ae422d2f35ed22ea2e6, it wasn't
the right fix. The right fix can be seen in https://github.com/saltstack/salt/pull/62078