### PR TITLE
Remove the redundant `wheel` dependency from pyproject.toml.

### DIFF
--- a/changelog/15.trivial.rst
+++ b/changelog/15.trivial.rst
@@ -1,0 +1,8 @@
+Remove the redundant `wheel` dependency from pyproject.toml.
+
+The setuptools backend takes care of adding it automatically
+via `setuptools.build_meta.get_requires_for_build_wheel()` since day
+one.  The documentation has historically been wrong about listing it,
+and it has been fixed since.
+
+See https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=50.3.2", "wheel", "setuptools-declarative-requirements", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=50.3.2", "setuptools-declarative-requirements", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This is actually the work done in #15.

Closes #15