### PR TITLE
Account for ``ProcessLookupError`` when terminating the underlying process

### DIFF
--- a/changelog/18.bugfix.rst
+++ b/changelog/18.bugfix.rst
@@ -1,0 +1,1 @@
+Account for ``ProcessLookupError`` when terminating the underlying process.

--- a/src/pytestshellutils/downgraded/shell.py
+++ b/src/pytestshellutils/downgraded/shell.py
@@ -194,13 +194,16 @@ class SubprocessImpl:
                 if child not in self._children:
                     self._children.append(child)
         with self._terminal:
-            if self.factory.slow_stop:
-                self._terminal.terminate()
-            else:
-                self._terminal.kill()
             try:
-                self._terminal.wait(10)
-            except subprocess.TimeoutExpired:
+                if self.factory.slow_stop:
+                    self._terminal.terminate()
+                else:
+                    self._terminal.kill()
+                try:
+                    self._terminal.wait(10)
+                except subprocess.TimeoutExpired:
+                    pass
+            except ProcessLookupError:
                 pass
             terminate_process(
                 pid=self._terminal.pid,

--- a/src/pytestshellutils/shell.py
+++ b/src/pytestshellutils/shell.py
@@ -212,16 +212,20 @@ class SubprocessImpl:
                     self._children.append(child)
 
         with self._terminal:
-            if self.factory.slow_stop:
-                self._terminal.terminate()
-            else:
-                self._terminal.kill()
             try:
-                # Allow the process to exit by itself in case slow_stop is True
-                self._terminal.wait(10)
-            except subprocess.TimeoutExpired:  # pragma: no cover
-                # The process failed to stop, no worries, we'll make sure it exit along with it's
-                # child processes bellow
+                if self.factory.slow_stop:
+                    self._terminal.terminate()
+                else:
+                    self._terminal.kill()
+                try:
+                    # Allow the process to exit by itself in case slow_stop is True
+                    self._terminal.wait(10)
+                except subprocess.TimeoutExpired:  # pragma: no cover
+                    # The process failed to stop, no worries, we'll make sure it exit along with it's
+                    # child processes bellow
+                    pass
+            except ProcessLookupError:
+                # The process is already gone
                 pass
             # Lets log and kill any child processes left behind, including the main subprocess
             # If it failed to properly stop


### PR DESCRIPTION
Fixes #18