### PR TITLE
The `Subprocess.run()` method can now override the `cwd`

### DIFF
--- a/changelog/33.bugfix.rst
+++ b/changelog/33.bugfix.rst
@@ -1,0 +1,1 @@
+The `Subprocess.run()` method can now override the `cwd`

--- a/src/pytestshellutils/downgraded/shell.py
+++ b/src/pytestshellutils/downgraded/shell.py
@@ -112,7 +112,10 @@ class SubprocessImpl:
         return self.factory.cmdline(*args)
 
     def init_terminal(
-        self, cmdline: List[str], env: Optional[EnvironDict] = None
+        self,
+        cmdline: List[str],
+        env: Optional[EnvironDict] = None,
+        cwd: Optional[Union[str, pathlib.Path]] = None,
     ) -> 'subprocess.Popen[Any]':
         """
         Instantiate a terminal with the passed command line(``cmdline``) and return it.
@@ -126,9 +129,11 @@ class SubprocessImpl:
                 List of strings to pass as ``args`` to :py:class:`~subprocess.Popen`
 
         Keyword Arguments:
-            environ:
+            env:
                 A dictionary of ``key``, ``value`` pairs to add to the
                 :py:attr:`pytestshellutils.shell.Factory.environ`.
+            cwd:
+                A path for the CWD when running the process.
 
         Returns:
             A :py:class:`~subprocess.Popen` instance.
@@ -150,7 +155,7 @@ class SubprocessImpl:
             stdout=self._terminal_stdout,
             stderr=self._terminal_stderr,
             shell=False,
-            cwd=str(self.factory.cwd),
+            cwd=str(cwd or self.factory.cwd),
             universal_newlines=True,
             close_fds=close_fds,
             env=environ,
@@ -274,16 +279,37 @@ class SubprocessImpl:
         return self._terminal.pid
 
     def run(
-        self, *args: str, env: Optional[EnvironDict] = None, **kwargs: Any
+        self,
+        *args: str,
+        env: Optional[EnvironDict] = None,
+        cwd: Optional[Union[str, pathlib.Path]] = None,
+        **kwargs: Any
     ) -> 'subprocess.Popen[Any]':
         """
         Run the given command synchronously.
+
+        Arguments:
+            args:
+                The command to run.
+
+        Keyword Arguments:
+            env:
+                A dictionary of ``key``, ``value`` pairs to add to the
+                :py:attr:`pytestshellutils.shell.Factory.environ`.
+            cwd:
+                A path for the CWD when running the process.
+
+        Returns:
+            A :py:class:`~subprocess.Popen` instance.
         """
         cmdline = self.cmdline(*args, **kwargs)
         log.info(
-            '%s is running %r in CWD: %s ...', self.factory, cmdline, self.factory.cwd
+            '%s is running %r in CWD: %s ...',
+            self.factory,
+            cmdline,
+            cwd or self.factory.cwd,
         )
-        return self.init_terminal(cmdline, env=env)
+        return self.init_terminal(cmdline, env=env, cwd=cwd)
 
 
 @attr.s(slots=True, kw_only=True)

--- a/src/pytestshellutils/shell.py
+++ b/src/pytestshellutils/shell.py
@@ -119,7 +119,10 @@ class SubprocessImpl:
         return self.factory.cmdline(*args)
 
     def init_terminal(
-        self, cmdline: List[str], env: Optional[EnvironDict] = None
+        self,
+        cmdline: List[str],
+        env: Optional[EnvironDict] = None,
+        cwd: Optional[Union[str, pathlib.Path]] = None,
     ) -> "subprocess.Popen[Any]":
         """
         Instantiate a terminal with the passed command line(``cmdline``) and return it.
@@ -133,9 +136,11 @@ class SubprocessImpl:
                 List of strings to pass as ``args`` to :py:class:`~subprocess.Popen`
 
         Keyword Arguments:
-            environ:
+            env:
                 A dictionary of ``key``, ``value`` pairs to add to the
                 :py:attr:`pytestshellutils.shell.Factory.environ`.
+            cwd:
+                A path for the CWD when running the process.
 
         Returns:
             A :py:class:`~subprocess.Popen` instance.
@@ -160,7 +165,7 @@ class SubprocessImpl:
             stdout=self._terminal_stdout,
             stderr=self._terminal_stderr,
             shell=False,
-            cwd=str(self.factory.cwd),
+            cwd=str(cwd or self.factory.cwd),
             universal_newlines=True,
             close_fds=close_fds,
             env=environ,
@@ -313,14 +318,32 @@ class SubprocessImpl:
         return self._terminal.pid
 
     def run(
-        self, *args: str, env: Optional[EnvironDict] = None, **kwargs: Any
+        self,
+        *args: str,
+        env: Optional[EnvironDict] = None,
+        cwd: Optional[Union[str, pathlib.Path]] = None,
+        **kwargs: Any,
     ) -> "subprocess.Popen[Any]":
         """
         Run the given command synchronously.
+
+        Arguments:
+            args:
+                The command to run.
+
+        Keyword Arguments:
+            env:
+                A dictionary of ``key``, ``value`` pairs to add to the
+                :py:attr:`pytestshellutils.shell.Factory.environ`.
+            cwd:
+                A path for the CWD when running the process.
+
+        Returns:
+            A :py:class:`~subprocess.Popen` instance.
         """
         cmdline = self.cmdline(*args, **kwargs)
-        log.info("%s is running %r in CWD: %s ...", self.factory, cmdline, self.factory.cwd)
-        return self.init_terminal(cmdline, env=env)
+        log.info("%s is running %r in CWD: %s ...", self.factory, cmdline, cwd or self.factory.cwd)
+        return self.init_terminal(cmdline, env=env, cwd=cwd)
 
 
 @attr.s(slots=True, kw_only=True)

--- a/tests/functional/shell/test_fixture.py
+++ b/tests/functional/shell/test_fixture.py
@@ -1,7 +1,9 @@
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
+import pathlib
 import sys
+import tempfile
 
 from pytestshellutils.shell import Subprocess
 from tests.conftest import Tempfiles
@@ -19,3 +21,19 @@ def test_run_call(tempfiles: Tempfiles, shell: Subprocess) -> None:
     )
     result = shell.run(sys.executable, script)
     assert result.returncode == 0
+
+
+def test_run_cwd(tempfiles: Tempfiles, shell: Subprocess) -> None:
+    system_tempdir = str(pathlib.Path(tempfile.gettempdir()).resolve())
+    assert str(shell.cwd.resolve()) != system_tempdir
+    script = tempfiles.makepyfile(
+        """
+        # coding=utf-8
+        import pathlib
+        print(str(pathlib.Path.cwd().resolve()), flush=True)
+        exit(0)
+        """
+    )
+    result = shell.run(sys.executable, script, cwd=system_tempdir)
+    assert result.returncode == 0
+    assert result.stdout.strip() == system_tempdir


### PR DESCRIPTION
Fixes #33