### PR TITLE
``Subprocess.run()`` now accepts ``shell`` keyword argument like ``subprocess.Popen``

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,7 @@ repos:
         name: Run bandit against the code base
         args: [--silent, -lll, --skip, B701]
         files: ^(?!tests/).*\.py$
-        exclude: src/pytestshellutils/version.py
+        exclude: ^src/pytestshellutils/(version|downgraded/shell)\.py$
   - repo: https://github.com/PyCQA/bandit
     rev: "1.7.4"
     hooks:

--- a/changelog/32.bugfix.rst
+++ b/changelog/32.bugfix.rst
@@ -1,0 +1,1 @@
+``Subprocess.run()`` now accepts ``shell`` keyword argument like ``subprocess.Popen``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,8 @@ title_format = "shell-utilities {version} ({project_date})"
   directory = "trivial"
   name = "Trivial/Internal Changes"
   showcontent = true
+
+[tool.bandit]
+exclude = [
+  "src/pytestshellutils/downgraded/shell.py"
+]

--- a/src/pytestshellutils/downgraded/shell.py
+++ b/src/pytestshellutils/downgraded/shell.py
@@ -114,6 +114,7 @@ class SubprocessImpl:
     def init_terminal(
         self,
         cmdline: List[str],
+        shell: bool = False,
         env: Optional[EnvironDict] = None,
         cwd: Optional[Union[str, pathlib.Path]] = None,
     ) -> 'subprocess.Popen[Any]':
@@ -129,6 +130,8 @@ class SubprocessImpl:
                 List of strings to pass as ``args`` to :py:class:`~subprocess.Popen`
 
         Keyword Arguments:
+            shell:
+                Pass the value of ``shell`` to :py:class:`~subprocess.Popen`
             env:
                 A dictionary of ``key``, ``value`` pairs to add to the
                 :py:attr:`pytestshellutils.shell.Factory.environ`.
@@ -154,7 +157,7 @@ class SubprocessImpl:
             cmdline,
             stdout=self._terminal_stdout,
             stderr=self._terminal_stderr,
-            shell=False,
+            shell=shell,
             cwd=str(cwd or self.factory.cwd),
             universal_newlines=True,
             close_fds=close_fds,
@@ -281,6 +284,7 @@ class SubprocessImpl:
     def run(
         self,
         *args: str,
+        shell: bool = False,
         env: Optional[EnvironDict] = None,
         cwd: Optional[Union[str, pathlib.Path]] = None,
         **kwargs: Any
@@ -293,6 +297,9 @@ class SubprocessImpl:
                 The command to run.
 
         Keyword Arguments:
+            shell:
+                Pass the value of `shell` to
+                :py:meth:`pytestshellutils.shell.Factory.init_terminal`
             env:
                 A dictionary of ``key``, ``value`` pairs to add to the
                 :py:attr:`pytestshellutils.shell.Factory.environ`.
@@ -309,7 +316,7 @@ class SubprocessImpl:
             cmdline,
             cwd or self.factory.cwd,
         )
-        return self.init_terminal(cmdline, env=env, cwd=cwd)
+        return self.init_terminal(cmdline, shell=shell, env=env, cwd=cwd)
 
 
 @attr.s(slots=True, kw_only=True)

--- a/src/pytestshellutils/shell.py
+++ b/src/pytestshellutils/shell.py
@@ -121,6 +121,7 @@ class SubprocessImpl:
     def init_terminal(
         self,
         cmdline: List[str],
+        shell: bool = False,
         env: Optional[EnvironDict] = None,
         cwd: Optional[Union[str, pathlib.Path]] = None,
     ) -> "subprocess.Popen[Any]":
@@ -136,6 +137,8 @@ class SubprocessImpl:
                 List of strings to pass as ``args`` to :py:class:`~subprocess.Popen`
 
         Keyword Arguments:
+            shell:
+                Pass the value of ``shell`` to :py:class:`~subprocess.Popen`
             env:
                 A dictionary of ``key``, ``value`` pairs to add to the
                 :py:attr:`pytestshellutils.shell.Factory.environ`.
@@ -164,7 +167,7 @@ class SubprocessImpl:
             cmdline,
             stdout=self._terminal_stdout,
             stderr=self._terminal_stderr,
-            shell=False,
+            shell=shell,  # nosec B602
             cwd=str(cwd or self.factory.cwd),
             universal_newlines=True,
             close_fds=close_fds,
@@ -320,6 +323,7 @@ class SubprocessImpl:
     def run(
         self,
         *args: str,
+        shell: bool = False,
         env: Optional[EnvironDict] = None,
         cwd: Optional[Union[str, pathlib.Path]] = None,
         **kwargs: Any,
@@ -332,6 +336,9 @@ class SubprocessImpl:
                 The command to run.
 
         Keyword Arguments:
+            shell:
+                Pass the value of `shell` to
+                :py:meth:`pytestshellutils.shell.Factory.init_terminal`
             env:
                 A dictionary of ``key``, ``value`` pairs to add to the
                 :py:attr:`pytestshellutils.shell.Factory.environ`.
@@ -343,7 +350,7 @@ class SubprocessImpl:
         """
         cmdline = self.cmdline(*args, **kwargs)
         log.info("%s is running %r in CWD: %s ...", self.factory, cmdline, cwd or self.factory.cwd)
-        return self.init_terminal(cmdline, env=env, cwd=cwd)
+        return self.init_terminal(cmdline, shell=shell, env=env, cwd=cwd)
 
 
 @attr.s(slots=True, kw_only=True)

--- a/tests/functional/shell/test_fixture.py
+++ b/tests/functional/shell/test_fixture.py
@@ -5,6 +5,8 @@ import pathlib
 import sys
 import tempfile
 
+import pytest
+
 from pytestshellutils.shell import Subprocess
 from tests.conftest import Tempfiles
 
@@ -37,3 +39,12 @@ def test_run_cwd(tempfiles: Tempfiles, shell: Subprocess) -> None:
     result = shell.run(sys.executable, script, cwd=system_tempdir)
     assert result.returncode == 0
     assert result.stdout.strip() == system_tempdir
+
+
+def test_run_shell(shell: Subprocess) -> None:
+    with pytest.raises(FileNotFoundError):
+        shell.run("exit", "0")
+    with pytest.raises(FileNotFoundError):
+        shell.run("exit", "0", shell=False)
+    result = shell.run("exit", "0", shell=True)
+    assert result.returncode == 0

--- a/tests/functional/shell/test_subprocess.py
+++ b/tests/functional/shell/test_subprocess.py
@@ -228,3 +228,13 @@ def test_run_cwd(tmp_path: str, tempfiles: Tempfiles, shell: Subprocess) -> None
     result = shell.run(sys.executable, script, cwd=system_tempdir)
     assert result.returncode == 0
     assert result.stdout.strip() == system_tempdir
+
+
+def test_run_shell() -> None:
+    shell = Subprocess()
+    with pytest.raises(FileNotFoundError):
+        shell.run("exit", "0")
+    with pytest.raises(FileNotFoundError):
+        shell.run("exit", "0", shell=False)
+    result = shell.run("exit", "0", shell=True)
+    assert result.returncode == 0


### PR DESCRIPTION
Fixes #32