### PR TITLE
Adjusted psutil to 5.8.0 or higher

### DIFF
--- a/changelog/53.improvement.rst
+++ b/changelog/53.improvement.rst
@@ -1,0 +1,1 @@
+Adjusted requirment for psutil to 5.8.0 or higher

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 pytest>=7.4.0
 attrs>=22.1.0
-psutil>=5.0.0
+psutil>=5.8.0
 pytest-helpers-namespace
 pytest-skip-markers


### PR DESCRIPTION
Fixes issue https://github.com/saltstack/pytest-shell-utilities/issues/52

A previous commit where psutil==6.0.0 appears to have been merged out, adjusting to psutil>=5.8.0 which is the base requirement for Salt 3006.x.  This will help reduce conflicits.

The same psutil==6.0.0 merge also added use of 'net_connections' to src/pytestshellutils/shell.py which is still present.