### PR TITLE
Revert requirements for psutil and allow for connections / net_connections based on psutil version

### DIFF
--- a/changelog/55.improvement.rst
+++ b/changelog/55.improvement.rst
@@ -1,0 +1,1 @@
+Revert requirements for psutil and allow for connections / net_connections based on psutil version

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 pytest>=7.4.0
 attrs>=22.1.0
-psutil>=6.0.0
+psutil>=5.0.0
 pytest-helpers-namespace
 pytest-skip-markers


### PR DESCRIPTION
Rigid support for net_connections was causing breakages, hence monitor version of psutil and call connections vs net_connections appropriately