### PR TITLE
Support pytest 9

### DIFF
--- a/tests/functional/shell/test_script_subprocess.py
+++ b/tests/functional/shell/test_script_subprocess.py
@@ -8,7 +8,10 @@ from typing import Any
 from typing import cast
 
 import pytest
-from pytest_subtests import SubTests
+try:
+    from pytest import Subtests as SubTests
+except ImportError:
+    from pytest_subtests import SubTests
 
 from pytestshellutils.customtypes import EnvironDict
 from pytestshellutils.exceptions import FactoryTimeout

--- a/tests/unit/utils/processes/test_processresult.py
+++ b/tests/unit/utils/processes/test_processresult.py
@@ -8,7 +8,10 @@ import logging
 import textwrap
 
 import pytest
-from pytest_subtests import SubTests
+try:
+    from pytest import Subtests as SubTests
+except ImportError:
+    from pytest_subtests import SubTests
 
 from pytestshellutils.utils.processes import ProcessResult
 


### PR DESCRIPTION
pytest 9 has included support for subtests, marking pytest_subtests as unmaintained at the same time -- attempt to import from pytest first, falling back to pytest_subtests if required.